### PR TITLE
Edited run-as/package.c via GitHub

### DIFF
--- a/run-as/package.c
+++ b/run-as/package.c
@@ -44,7 +44,8 @@
 #define PACKAGES_LIST_FILE  "/data/system/packages.list"
 
 /* This should be large enough to hold the content of the package database file */
-#define PACKAGES_LIST_BUFFER_SIZE  8192
+/* Bump size to 64K */
+#define PACKAGES_LIST_BUFFER_SIZE  65536
 
 /* Copy 'srclen' string bytes from 'src' into buffer 'dst' of size 'dstlen'
  * This function always zero-terminate the destination buffer unless


### PR DESCRIPTION
fix to allow packages.list to be read when larger than 8K.  
