### PR TITLE
adbd:fix framebuffer when(fbinfo.size % 640 != 0)

### DIFF
--- a/adb/framebuffer_service.c
+++ b/adb/framebuffer_service.c
@@ -161,7 +161,7 @@ void framebuffer_service(int fd, void *cookie)
     if(writex(fd, &fbinfo, sizeof(fbinfo))) goto done;
 
     /* write data */
-    for(i = 0; i < fbinfo.size; i += sizeof(buf)) {
+    for(i = sizeof(buf) - 1; i < fbinfo.size; i += sizeof(buf)) {
       if(readx(fd_screencap, buf, sizeof(buf))) goto done;
       if(writex(fd, buf, sizeof(buf))) goto done;
     }


### PR DESCRIPTION
Already submit the Issue in https://code.google.com/p/android/issues/detail?id=38347
