### PR TITLE
Update audio.h

### DIFF
--- a/include/system/audio.h
+++ b/include/system/audio.h
@@ -516,9 +516,12 @@ enum {
                                AUDIO_DEVICE_IN_USB_DEVICE |
                                AUDIO_DEVICE_IN_PROXY |
                                AUDIO_DEVICE_IN_ANC_HEADSET |
-#ifdef QCOM_HARDWARE && !defined(ICS_AUDIO_BLOB) && !defined(MR0_AUDIO_BLOB)
+#ifdef QCOM_HARDWARE
+#if !defined(ICS_AUDIO_BLOB) && !defined(MR0_AUDIO_BLOB)
+
                                AUDIO_DEVICE_IN_FM_RX |
                                AUDIO_DEVICE_IN_FM_RX_A2DP |
+#endif
 #endif
                                AUDIO_DEVICE_IN_DEFAULT),
     AUDIO_DEVICE_IN_ALL_SCO = AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET,

--- a/include/system/audio.h
+++ b/include/system/audio.h
@@ -516,7 +516,7 @@ enum {
                                AUDIO_DEVICE_IN_USB_DEVICE |
                                AUDIO_DEVICE_IN_PROXY |
                                AUDIO_DEVICE_IN_ANC_HEADSET |
-#ifdef QCOM_HARDWARE
+#ifdef QCOM_HARDWARE && !defined(ICS_AUDIO_BLOB) && !defined(MR0_AUDIO_BLOB)
                                AUDIO_DEVICE_IN_FM_RX |
                                AUDIO_DEVICE_IN_FM_RX_A2DP |
 #endif


### PR DESCRIPTION
fix error if define ICS_AUDIO_BLOB.
system/core/include/system/audio.h:520:32: error: 'AUDIO_DEVICE_IN_FM_RX' undeclared here (not in a function)
                                AUDIO_DEVICE_IN_FM_RX |
                                ^
system/core/include/system/audio.h:521:32: error: 'AUDIO_DEVICE_IN_FM_RX_A2DP' undeclared here (not in a function)
                                AUDIO_DEVICE_IN_FM_RX_A2DP |
                                ^
