### PR TITLE
Update unpackbootimg.c

### DIFF
--- a/mkbootimg/unpackbootimg.c
+++ b/mkbootimg/unpackbootimg.c
@@ -74,6 +74,18 @@ int main(int argc, char** argv)
     if (filename == NULL) {
         return usage();
     }
+
+    // does directory exist? 
+    if (access(directory, F_OK) == -1) {
+        if(errno == ENOENT) {
+            printf("directory does not exist: '%s'\n", directory);
+        } else if (errno == ENOTDIR) {
+            printf("file is not a directory: '%s'\n", directory);
+        } else {
+            printf("could not access directory: '%s'\n", directory);
+        }
+        return usage();
+    }
     
     int total_read = 0;
     FILE* f = fopen(filename, "rb");


### PR DESCRIPTION
Unpackbootimg should not segfault when directory does not exist.

```
$ unpackbootimg -i boot.img -o directory_that_does_not_exist
Android magic found at: 0
BOARD_KERNEL_CMDLINE 
BOARD_KERNEL_BASE 10000000
BOARD_RAMDISK_OFFSET 01000000
BOARD_SECOND_OFFSET 00f00000
BOARD_TAGS_OFFSET f0082800
BOARD_PAGE_SIZE 33554432
BOARD_SECOND_SIZE 0
BOARD_DT_SIZE 268435712
[1]    20114 segmentation fault  unpackbootimg -i boot.img -o directory_that_does_not_exist
```

My fix checks for the directory before proceeding. 
